### PR TITLE
♻️ (model) uses link method rather than manually building link

### DIFF
--- a/src/FrontEndEditLink.php
+++ b/src/FrontEndEditLink.php
@@ -11,23 +11,23 @@ use SilverStripe\Dev\Debug;
 
 class FrontEndEditLink extends DataExtension
 {
-
-    public function EditLink(){
-
+    public function EditLink()
+    {
         if ($member = Security::getCurrentUser()) {
-            return DBField::create_field('HTMLFragment',"<a href='admin/pages/edit/show/".$this->owner->ID."/' style='
-            position: fixed;
-            z-index: 1000;
-            bottom: 0;
-            left: 0;
-            background: #f90;
-            padding: 0 3px;
-            font-size: 12px;
-            color: #fff;
-            ' target='_blank' rel='nofollow'>Edit</a>");
+            return DBField::create_field(
+                'HTMLFragment', "<a href='". $this->owner->CMSEditLink() . "/' style='
+                position: fixed;
+                z-index: 1000;
+                bottom: 0;
+                left: 0;
+                background: #f90;
+                padding: 0 3px;
+                font-size: 12px;
+                color: #fff;
+                ' target='_blank' rel='nofollow'>Edit</a>"
+            );
         }
 
         return NULL;
     }
-
 }


### PR DESCRIPTION
@sinan-evanshunt I haven't tested this, as I don't have this module installed on any active projects, but I found the built in `CMSEditLink()` method digging through the SiteTree source and thought it might be a fit for this module.